### PR TITLE
Add Console `make:transition` Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All Notable changes to `http-transitions` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## NEXT - YYYY-MM-DD
+## [v0.2.0] - 2017-09-18
 
 ### Added
-- Nothing
+- Console commands to generate transition classes.
 
 ### Deprecated
 - Nothing

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ class NameToFirstNameLastNameTransition extends Transition
 }
 ```
 
+## Transition Generators
+```bash
+$ php artisan make:transition NameToFirstNameLastNameTransition
+```
+Optionally, the `--request-only` or `--response-only` flags can be added to create a transform that only generates a `transformRequest` or `transformResponse` method respectively.
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/src/Console/GenerateTransition.php
+++ b/src/Console/GenerateTransition.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Transitions\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class GenerateTransition extends GeneratorCommand
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:transition {name} {--request-only} {--response-only}';
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create an HTTP transition';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('request-only')) {
+            return __DIR__ . '/../../stubs/request_only_transition.stub';
+        }
+        if ($this->option('response-only')) {
+            return __DIR__ . '/../../stubs/response_only_transition.stub';
+        }
+
+        return __DIR__ . '/../../stubs/transition.stub';
+    }
+
+    /**
+     * Build the model class with the given name.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+
+        $stub = $this->files->get($this->getStub());
+
+        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+
+        return "$rootNamespace\\Http\\Transitions";
+    }
+}

--- a/src/TransitionProvider.php
+++ b/src/TransitionProvider.php
@@ -3,6 +3,7 @@
 namespace Transitions;
 
 use Illuminate\Support\ServiceProvider;
+use Transitions\Console\GenerateTransition;
 
 /**
  * Class TransitionProvider
@@ -30,5 +31,7 @@ class TransitionProvider extends ServiceProvider
             $config = new Config($app['config']->get('transitions'));
             return new TransitionMiddleware($config, $app);
         });
+
+        $this->commands([GenerateTransition::class]);
     }
 }

--- a/stubs/request_only_transition.stub
+++ b/stubs/request_only_transition.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Request;
+use Transitions\Transition;
+
+/**
+ * Class DummyClass
+ */
+class DummyClass extends Transition
+{
+
+    /**
+     * @param Request $request
+     * @return Request
+     */
+    public function transformRequest(Request $request) : Request
+    {
+
+        return $request;
+    }
+}

--- a/stubs/response_only_transition.stub
+++ b/stubs/response_only_transition.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace DummyNamespace;
+
+use Symfony\Component\HttpFoundation\Response;
+use Transitions\Transition;
+
+/**
+ * Class DummyClass
+ */
+class DummyClass extends Transition
+{
+
+    /**
+     * @param Response $response
+     * @return Response
+     */
+    public function transformResponse(Response $response) : Response
+    {
+
+        return $response;
+    }
+}

--- a/stubs/transition.stub
+++ b/stubs/transition.stub
@@ -1,0 +1,34 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Transitions\Transition;
+
+/**
+ * Class DummyClass
+ */
+class DummyClass extends Transition
+{
+
+    /**
+     * @param Request $request
+     * @return Request
+     */
+    public function transformRequest(Request $request) : Request
+    {
+
+        return $request;
+    }
+
+    /**
+     * @param Response $response
+     * @return Response
+     */
+    public function transformResponse(Response $response) : Response
+    {
+
+        return $response;
+    }
+}

--- a/tests/Console/GenerateTransitionTest.php
+++ b/tests/Console/GenerateTransitionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Transitions\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Transitions\TestCase;
+
+class GenerateTransitionTest extends TestCase
+{
+
+    /** @var  Filesystem */
+    protected $files;
+
+    public function setUp()
+    {
+
+        parent::setUp();
+        $this->files = $this->app->make(Filesystem::class);
+    }
+
+    /** @test */
+    public function itGeneratesATransitionClass()
+    {
+
+        $path = app_path('Http/Transitions/TestTransition.php');
+        $this->artisan('make:transition', ['name' => 'TestTransition']);
+        $this->assertFileExists($path);
+        $contents = $this->files->get($path);
+        $this->assertContains('namespace App\Http\Transitions;', $contents);
+        $this->assertContains('class TestTransition extends Transition', $contents);
+        $this->assertContains('public function transformRequest', $contents);
+        $this->assertContains('public function transformResponse', $contents);
+    }
+
+    /** @test */
+    public function itGeneratesARequestOnlyTransitionClass()
+    {
+
+        $path = app_path('Http/Transitions/TestRequestTransition.php');
+        $this->artisan('make:transition', ['name' => 'TestRequestTransition', '--request-only' => true]);
+        $this->assertFileExists($path);
+        $contents = $this->files->get($path);
+        $this->assertContains('public function transformRequest', $contents);
+        $this->assertNotContains('public function transformResponse', $contents);
+    }
+
+    /** @test */
+    public function itGeneratesAResponseOnlyTransitionClass()
+    {
+
+        $path = app_path('Http/Transitions/TestResponseTransition.php');
+        $this->artisan('make:transition', ['name' => 'TestResponseTransition', '--response-only' => true]);
+        $this->assertFileExists($path);
+        $contents = $this->files->get($path);
+        $this->assertContains('public function transformResponse', $contents);
+        $this->assertNotContains('public function transformRequest', $contents);
+    }
+
+
+
+    public function tearDown()
+    {
+        $this->files->cleanDirectory(app_path('Http/Transitions'));
+    }
+}


### PR DESCRIPTION
Example:
```bash
$ php artisan make:transition CurrentToPrevious --response-only
```

## Description
Added a console command to quickly generate a new transition and flags to limit the generated to code to either just `transfromRequest` or `transformResponse`.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.