### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 7.1
+  - 7.2
+  - 7.3
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,15 @@
     "license" : "MIT",
     "require" : {
         "php" : "^7.1",
-        "illuminate/config" : "5.4.*|5.5.*|5.6.*",
-        "illuminate/contracts" : "5.4.*|5.5.*|5.6.*",
-        "illuminate/http" : "5.4.*|5.5.*|5.6.*",
-        "illuminate/support" : "5.4.*|5.5.*|5.6.*"
+        "ext-json": "*",
+        "illuminate/config" : "5.5.*|5.6.*|5.7.*",
+        "illuminate/contracts" : "5.5.*|5.6.*|5.7.*",
+        "illuminate/http" : "5.5.*|5.6.*|5.7.*",
+        "illuminate/support" : "5.5.*|5.6.*|5.7.*"
     },
     "require-dev" : {
         "phpunit/phpunit" : "^7.0",
-        "orchestra/testbench" : "~3.6",
+        "orchestra/testbench" : "~3.7",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload" : {

--- a/tests/Console/GenerateTransitionTest.php
+++ b/tests/Console/GenerateTransitionTest.php
@@ -16,6 +16,7 @@ class GenerateTransitionTest extends TestCase
 
         parent::setUp();
         $this->files = $this->app->make(Filesystem::class);
+        $this->withoutMockingConsoleOutput();
     }
 
     /** @test */


### PR DESCRIPTION
- update .travis to run php 7.2 and 7.3
- dropped Laravel 5.4 and added 5.7
- explicitly disabled mocking of artisan command to fix `Mockery` not found issue.